### PR TITLE
Fix asset path in deploy script

### DIFF
--- a/deploy-assets.sh
+++ b/deploy-assets.sh
@@ -4,7 +4,7 @@
 BRANCH="main"  # or change if you're working from a different branch
 REPO_URL="https://github.com/Plugnplaytv/plugnplayiptv.github.io.git"
 IMAGE_SOURCE_DIR="./new-images"  # folder where you place new .png/.jpg files
-TARGET_DIR="./img"
+TARGET_DIR="./images"
 
 # ---- CLONE & SYNC ----
 echo "Cloning repo..."


### PR DESCRIPTION
## Summary
- update deploy script path to use `images` directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684615a0f3ec832babe508bfb5f4698b