### PR TITLE
Fix Shop Now button link

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     <div class="text">
       <h1>Plug &amp; Play 4K Firestick IPTV</h1>
       <p>12,000+ Live Channels • 8,000 Movies On Demand • PPV &amp; Sports</p>
-      <a class="btn" href="#pricing">Shop Now</a>
+      <a class="btn" href="pricing.html">Shop Now</a>
       <a class="btn-alt" href="#how-it-works">How It Works</a>
     </div>
     <div class="media">


### PR DESCRIPTION
## Summary
- update **Shop Now** button to link to the pricing page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846867b9a44832b879b369b227886b8