### PR TITLE
Add renewal rates toggle to pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -35,11 +35,15 @@
         <button class="toggle-btn active" data-duration="6">6 Months</button>
         <button class="toggle-btn" data-duration="12">12 Months</button>
       </div>
+      <div class="renewal-toggle">
+        <button class="toggle-btn renewal-btn active" data-renewal="off">Hide Renewal Rates</button>
+        <button class="toggle-btn renewal-btn" data-renewal="on">Show Renewal Rates</button>
+      </div>
 
       <div class="plan-grid">
         <div class="plan-card" data-duration="6">
           <h3>1 Device</h3>
-          <p class="price">$210</p>
+          <p class="price">$210 <span class="renewal-rate">Renewal at $20.99/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_6M1">
@@ -48,7 +52,7 @@
         </div>
         <div class="plan-card" data-duration="6">
           <h3>2 Devices</h3>
-          <p class="price">$405</p>
+          <p class="price">$405 <span class="renewal-rate">Renewal at $20.99/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_6M2">
@@ -57,7 +61,7 @@
         </div>
         <div class="plan-card" data-duration="6">
           <h3>3 Devices</h3>
-          <p class="price">$599</p>
+          <p class="price">$599 <span class="renewal-rate">Renewal at $20.99/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_6M3">
@@ -66,7 +70,7 @@
         </div>
         <div class="plan-card" data-duration="6">
           <h3>4 Devices <small>(5% off)</small></h3>
-          <p class="price">$760</p>
+          <p class="price">$760 <span class="renewal-rate">Renewal at $20.99/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_6M4">
@@ -75,7 +79,7 @@
         </div>
         <div class="plan-card" data-duration="6">
           <h3>5 Devices <small>(10% off)</small></h3>
-          <p class="price">$900</p>
+          <p class="price">$900 <span class="renewal-rate">Renewal at $20.99/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_6M5">
@@ -85,7 +89,7 @@
 
         <div class="plan-card" data-duration="12">
           <h3>1 Device</h3>
-          <p class="price">$250</p>
+          <p class="price">$250 <span class="renewal-rate">Renewal at $18.50/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_1Y1">
@@ -94,7 +98,7 @@
         </div>
         <div class="plan-card" data-duration="12">
           <h3>2 Devices</h3>
-          <p class="price">$455</p>
+          <p class="price">$455 <span class="renewal-rate">Renewal at $18.50/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_1Y2">
@@ -103,7 +107,7 @@
         </div>
         <div class="plan-card" data-duration="12">
           <h3>3 Devices</h3>
-          <p class="price">$655</p>
+          <p class="price">$655 <span class="renewal-rate">Renewal at $18.50/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_1Y3">
@@ -112,7 +116,7 @@
         </div>
         <div class="plan-card" data-duration="12">
           <h3>4 Devices <small>(5% off)</small></h3>
-          <p class="price">$790</p>
+          <p class="price">$790 <span class="renewal-rate">Renewal at $18.50/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_1Y4">
@@ -121,7 +125,7 @@
         </div>
         <div class="plan-card" data-duration="12">
           <h3>5 Devices <small>(10% off)</small></h3>
-          <p class="price">$935</p>
+          <p class="price">$935 <span class="renewal-rate">Renewal at $18.50/mo</span></p>
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <input type="hidden" name="cmd" value="_s-xclick">
             <input type="hidden" name="hosted_button_id" value="ID_1Y5">

--- a/scripts/pricing-toggle.js
+++ b/scripts/pricing-toggle.js
@@ -17,4 +17,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const active = document.querySelector('.toggle-btn.active');
   if (active) showCards(active.dataset.duration);
+
+  // Renewal rates toggle
+  document.querySelectorAll('.renewal-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.renewal-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const show = btn.dataset.renewal === 'on';
+      document.querySelectorAll('.renewal-rate').forEach(el => {
+        el.style.display = show ? 'inline' : 'none';
+      });
+    });
+  });
 });

--- a/styles/main.css
+++ b/styles/main.css
@@ -229,6 +229,32 @@ footer.site-footer a:hover { text-decoration: underline }
 .plan-toggle .toggle-btn.active {
   background: var(--accent);
 }
+
+/* Renewal Rates Toggle */
+.renewal-toggle {
+  text-align: center;
+  margin: 1.5rem 0;
+}
+.renewal-toggle .renewal-btn {
+  background: #fff;
+  border: 1px solid var(--brand);
+  padding: 0.5rem 1rem;
+  margin: 0 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background .2s, color .2s;
+}
+.renewal-toggle .renewal-btn.active {
+  background: var(--brand);
+  color: #fff;
+}
+.renewal-rate {
+  display: none;
+  color: var(--accent);
+  font-weight: bold;
+  margin-left: 0.5rem;
+}
 .plan-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));


### PR DESCRIPTION
## Summary
- add renewal rates toggle buttons
- show renewal pricing info for all plans
- style renewal toggle and rates
- add JS to toggle renewal rate visibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684695efc84c832b802ad4a66c27d641