### PR TITLE
Create reusable header include

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,13 @@
+<header class="site-header">
+  <div class="logo">
+    <a href="/"><img src="/images/logo.png" alt="PlugNPlay IPTV"></a>
+  </div>
+  <nav class="main-nav">
+    <a href="/about"    class="active">About</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/reviews">Reviews</a>
+    <a href="/channels">Channels</a>
+    <a href="/support">Support</a>
+  </nav>
+</header>
+

--- a/channels.html
+++ b/channels.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>FAQ - PlugNPlay IPTV</title>
+  <title>Channels - PlugNPlay IPTV</title>
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
 <body class="simple">
-    {% include header.html %}
-
-  <h1>Frequently Asked Questions</h1>
-  <p>This page is coming soon. For help email <a href="mailto:support@plugnplayiptv.com">support@plugnplayiptv.com</a>.</p>
+  {% include header.html %}
+  <h1>Channel Lineup</h1>
+  <p>Channel listings will be added soon.</p>
 </body>
 </html>
+

--- a/contact.html
+++ b/contact.html
@@ -8,17 +8,7 @@
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
 <body class="simple">
-  <header class="site-header">
-    <div class="logo">
-      <a href="/"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
-    </div>
-    <nav class="main-nav">
-      <a href="index.html">Home</a>
-      <a href="pricing.html">Pricing</a>
-      <a href="faq.html">FAQ</a>
-      <a class="active" href="contact.html">Contact</a>
-    </nav>
-  </header>
+    {% include header.html %}
 
   <h1>Contact Us</h1>
   <p>Email <a href="mailto:support@plugnplayiptv.com">support@plugnplayiptv.com</a> for any questions.</p>

--- a/index.html
+++ b/index.html
@@ -19,17 +19,7 @@
 <body class="home">
 
   <!-- Site Header -->
-  <header class="site-header">
-    <div class="logo">
-      <a href="/"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
-    </div>
-    <nav class="main-nav">
-      <a class="active" href="index.html">Home</a>
-      <a href="pricing.html">Pricing</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </header>
+    {% include header.html %}
 
   <!-- Hero / About -->
   <section class="hero" id="about">

--- a/pricing.html
+++ b/pricing.html
@@ -14,17 +14,7 @@
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
 <body class="pricing">
-  <header class="site-header">
-    <div class="logo">
-      <a href="/"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
-    </div>
-    <nav class="main-nav">
-      <a href="index.html">Home</a>
-      <a class="active" href="pricing.html">Pricing</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </header>
+    {% include header.html %}
 
   <main role="main">
     <section class="pricing-plans">

--- a/privacy.html
+++ b/privacy.html
@@ -8,17 +8,7 @@
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
 <body class="simple">
-  <header class="site-header">
-    <div class="logo">
-      <a href="/"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
-    </div>
-    <nav class="main-nav">
-      <a href="index.html">Home</a>
-      <a href="pricing.html">Pricing</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </header>
+    {% include header.html %}
 
   <h1>Privacy Policy</h1>
   <p>This policy will outline how we handle your information. Details coming soon.</p>

--- a/reviews.html
+++ b/reviews.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>FAQ - PlugNPlay IPTV</title>
+  <title>Reviews - PlugNPlay IPTV</title>
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
 <body class="simple">
-    {% include header.html %}
-
-  <h1>Frequently Asked Questions</h1>
-  <p>This page is coming soon. For help email <a href="mailto:support@plugnplayiptv.com">support@plugnplayiptv.com</a>.</p>
+  {% include header.html %}
+  <h1>Customer Reviews</h1>
+  <p>This page is coming soon. Check back later for testimonials.</p>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add shared header.html include with nav links
- use the new header include on all pages
- add placeholder reviews and channels pages using the shared header

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846968005c0832b97086a32694200a6