### PR TITLE
Inline header markup to show navbar

### DIFF
--- a/channels.html
+++ b/channels.html
@@ -7,8 +7,19 @@
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
-<body class="simple">
-  {% include header.html %}
+  <body class="simple">
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
   <h1>Channel Lineup</h1>
   <p>Channel listings will be added soon.</p>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -7,8 +7,19 @@
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
-<body class="simple">
-    {% include header.html %}
+  <body class="simple">
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
 
   <h1>Contact Us</h1>
   <p>Email <a href="mailto:support@plugnplayiptv.com">support@plugnplayiptv.com</a> for any questions.</p>

--- a/faq.html
+++ b/faq.html
@@ -7,8 +7,19 @@
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
-<body class="simple">
-    {% include header.html %}
+  <body class="simple">
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
 
   <h1>Frequently Asked Questions</h1>
   <p>This page is coming soon. For help email <a href="mailto:support@plugnplayiptv.com">support@plugnplayiptv.com</a>.</p>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,18 @@
 <body class="home">
 
   <!-- Site Header -->
-    {% include header.html %}
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
 
   <!-- Hero / About -->
   <section class="hero" id="about">

--- a/pricing.html
+++ b/pricing.html
@@ -13,8 +13,19 @@
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
-<body class="pricing">
-    {% include header.html %}
+  <body class="pricing">
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
 
   <main role="main">
     <section class="pricing-plans">

--- a/privacy.html
+++ b/privacy.html
@@ -7,8 +7,19 @@
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
-<body class="simple">
-    {% include header.html %}
+  <body class="simple">
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
 
   <h1>Privacy Policy</h1>
   <p>This policy will outline how we handle your information. Details coming soon.</p>

--- a/reviews.html
+++ b/reviews.html
@@ -7,8 +7,19 @@
   <link rel="icon" href="images/logo.png" />
   <link rel="stylesheet" href="styles/main.css"/>
 </head>
-<body class="simple">
-  {% include header.html %}
+  <body class="simple">
+  <header class="site-header">
+    <div class="logo">
+      <a href="index.html"><img src="images/logo.png" alt="PlugNPlay IPTV"></a>
+    </div>
+    <nav class="main-nav">
+      <a href="index.html#about">About</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="reviews.html">Reviews</a>
+      <a href="index.html#channels">Channels</a>
+      <a href="index.html#support">Support</a>
+    </nav>
+  </header>
   <h1>Customer Reviews</h1>
   <p>This page is coming soon. Check back later for testimonials.</p>
 </body>


### PR DESCRIPTION
## Summary
- insert header markup directly in HTML pages

## Testing
- `grep -n "{\% include header.html %}" -R *.html`


------
https://chatgpt.com/codex/tasks/task_e_68469a6e72cc832b9f0a32655e1fcfac