### PR TITLE
Add price list image

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -29,6 +29,7 @@
 
   <main role="main">
     <section class="pricing-plans">
+      <img src="images/price-lists.png" alt="Price Lists" class="pricing-header-image">
       <h1 class="section-title">Choose Your Plan</h1>
       <p class="section-subtitle">All Premium Channels, PPV &amp; Sports Pass Included • No Hidden Fees</p>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -199,6 +199,11 @@ footer.site-footer a:hover { text-decoration: underline }
   text-align: center;
   padding: 4rem 1rem;
 }
+.pricing-header-image {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 1.5rem;
+}
 .pricing-plans .section-title {
   font-size: 2.5rem;
   color: var(--brand);


### PR DESCRIPTION
## Summary
- show `price-lists.png` on pricing page
- style new pricing header image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68469cd5b954832ba958a20716f896cb