### PR TITLE
Show nav on home page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,6 @@
   <div class="logo">
     <a href="/"><img src="/images/logo.png" alt="PlugNPlay IPTV"></a>
   </div>
-  {% unless page.url == "/" or page.url == "/index.html" %}
   <button class="nav-toggle" aria-label="Toggle navigation">
     <span class="hamburger"></span>
   </button>
@@ -13,5 +12,4 @@
     <a href="faq.html"      class="{% if page.url == '/faq.html'      %}active{% endif %}">FAQ</a>
     <a href="contact.html"  class="{% if page.url == '/contact.html'  %}active{% endif %}">Contact</a>
   </nav>
-  {% endunless %}
 </header>

--- a/styles/main.css
+++ b/styles/main.css
@@ -74,14 +74,6 @@ nav.main-nav {
   .nav-toggle {
     display: block;
   }
-  /* On homepage, center logo and hide nav-toggle/nav */
-  body.home header.site-header {
-    justify-content: center;
-  }
-  body.home .nav-toggle,
-  body.home nav.main-nav {
-    display: none;
-  }
 }
 
 nav.main-nav a {


### PR DESCRIPTION
## Summary
- always render nav in header include
- remove CSS that hides nav on the home page

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846aac8d1d4832bbd251cdac50ff99a