### PR TITLE
Add Home tab to navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,7 @@
     <span class="hamburger"></span>
   </button>
   <nav class="main-nav">
+    <a href="index.html"   class="{% if page.url == '/index.html' or page.url == '/' %}active{% endif %}">Home</a>
     <a href="pricing.html"  class="{% if page.url == '/pricing.html'  %}active{% endif %}">Pricing</a>
     <a href="reviews.html"  class="{% if page.url == '/reviews.html'  %}active{% endif %}">Reviews</a>
     <a href="channels.html" class="{% if page.url == '/channels.html' %}active{% endif %}">Channels</a>


### PR DESCRIPTION
## Summary
- show a Home link in the shared navigation header
- keep indentation consistent

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846ae49e41c832bbbce5c3ae7dbe5a8